### PR TITLE
Add Forestry Filter Support Framework

### DIFF
--- a/src/main/java/mcjty/xnet/apiimpl/items/ItemFilterCache.java
+++ b/src/main/java/mcjty/xnet/apiimpl/items/ItemFilterCache.java
@@ -55,12 +55,25 @@ public class ItemFilterCache {
 
     private boolean itemMatches(ItemStack stack) {
         if (stacks != null) {
+            int forestryFlags = ForestrySupport.Tag.GEN.getFlag() | ForestrySupport.Tag.IS_ANALYZED.getFlag();
+            ItemStack cleanedStack = null;
+            if(nbtMode && ForestrySupport.isLoaded() && ForestrySupport.isBreedable(stack)) {
+                cleanedStack = ForestrySupport.sanitize(stack, forestryFlags);
+            }
             for (ItemStack itemStack : stacks) {
                 if (matchDamage && itemStack.getMetadata() != stack.getMetadata()) {
                     continue;
                 }
-                if (nbtMode && !ItemStack.areItemStackTagsEqual(itemStack, stack)) {
-                    continue;
+                if (nbtMode) {
+                    if((cleanedStack != null) && ForestrySupport.isBreedable(itemStack)) {
+                        ItemStack cleanedItemStack = ForestrySupport.sanitize(itemStack, forestryFlags);
+                        if(ItemStack.areItemStackTagsEqual(cleanedItemStack, cleanedStack)) {
+                    		return true;
+                    	}
+                    }
+                    if(!ItemStack.areItemStackTagsEqual(itemStack, stack)) {
+                        continue;
+                    }
                 }
                 if (itemStack.getItem().equals(stack.getItem())) {
                     return true;

--- a/src/main/java/mcjty/xnet/apiimpl/items/ItemFilterCache.java
+++ b/src/main/java/mcjty/xnet/apiimpl/items/ItemFilterCache.java
@@ -1,6 +1,7 @@
 package mcjty.xnet.apiimpl.items;
 
 import mcjty.lib.varia.ItemStackList;
+import mcjty.xnet.compat.ForestrySupport;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.oredict.OreDictionary;
 
@@ -67,11 +68,11 @@ public class ItemFilterCache {
                 if (nbtMode) {
                     if((cleanedStack != null) && ForestrySupport.isBreedable(itemStack)) {
                         ItemStack cleanedItemStack = ForestrySupport.sanitize(itemStack, forestryFlags);
-                        if(ItemStack.areItemStackTagsEqual(cleanedItemStack, cleanedStack)) {
-                    		return true;
+                        if(!ItemStack.areItemStackTagsEqual(cleanedItemStack, cleanedStack)) {
+                    		continue;
                     	}
                     }
-                    if(!ItemStack.areItemStackTagsEqual(itemStack, stack)) {
+                    else if(!ItemStack.areItemStackTagsEqual(itemStack, stack)) {
                         continue;
                     }
                 }

--- a/src/main/java/mcjty/xnet/compat/ForestrySupport.java
+++ b/src/main/java/mcjty/xnet/compat/ForestrySupport.java
@@ -1,0 +1,117 @@
+package mcjty.xnet.compat;
+
+
+import java.util.ArrayList;
+import java.util.Collections;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraftforge.fml.common.Loader;
+
+public final class ForestrySupport {
+    public enum Tag {
+    	GENOME("Genome", 1),	// Bees, Trees, Butterflies
+    	MATE("Mate", 2),		// Bees, Butterflies
+    	GEN("GEN", 4),			// Bees
+    	HEALTH("Health", 8),	// Bees, Butterflies
+    	IS_ANALYZED("IsAnalyzed", 16),	// Bees, Trees, Butterflies
+    	MAX_HEALTH("MaxH", 32),	// Bees, Butterflies
+    	AGE("Age", 64);			// Butterflies
+
+    	private String name;
+    	private int flag;
+	
+    	Tag(String name, int flag) {
+    		this.name = name;
+    		this.flag = flag;
+    	}
+	
+    	public int getFlag() {
+    		return flag;
+    	}
+    }
+
+    private static final String ID = "forestry";
+
+    private static final String QUEEN_BEE = "forestry:bee_queen_ge";
+    private static final String PRINCESS_BEE = "forestry:bee_princess_ge";
+    private static final String DRONE_BEE = "forestry:bee_drone_ge";
+    private static final String LARVAE_BEE = "forestry:bee_larvae_ge";
+
+    private static final String SAPLING = "forestry:sapling";
+    private static final String POLLEN = "forestry:pollen_fertile";
+
+    private static final String BUTTERFLY = "forestry:butterfly_ge";
+    private static final String SERUM = "forestry:serum_ge";
+    private static final String CATERPILLAR = "forestry:caterpillar_ge";
+    private static final String COCOON = "forestry:cocoon_ge";
+
+    private static final String[] FORESTRY_NAMES = { QUEEN_BEE, PRINCESS_BEE, DRONE_BEE, LARVAE_BEE, SAPLING, POLLEN,
+	    BUTTERFLY, SERUM, CATERPILLAR, COCOON };
+
+    public static boolean isLoaded() {
+	    return Loader.isModLoaded(ID);
+    }
+
+    /**
+     * Determines if the item is breedable in Forestry.
+     * 
+     * @param item	item being determined if breedable
+     * @return		true if breedable, else false
+     */
+    public static boolean isBreedable(ItemStack item) {
+        String itemName = item.getItem().getRegistryName().toString();
+        for (String forestryName : FORESTRY_NAMES) {
+	        if (itemName.equals(forestryName)) {
+	        	return true;
+	        }
+	    }
+	    return false;
+    }
+
+    /**
+     * Removes NBT tags based on the item to make it easier for comparison with
+     * other similar items.
+     *
+     * @param item	item to remove NBT tags from
+     * @return		the item with appropriate NBT tags removed
+     */
+    public static ItemStack sanitize(ItemStack item, int flags) {
+	    NBTTagCompound tagCompound = item.getTagCompound().copy();
+	    ArrayList<Tag> tagsToRemove = new ArrayList<>();
+	    switch (item.getItem().getRegistryName().toString()) {
+	        case QUEEN_BEE:
+	        case PRINCESS_BEE:
+	            tagsToRemove.add(Tag.GEN);
+	        case DRONE_BEE:
+	        case LARVAE_BEE:
+	            Collections.addAll(tagsToRemove, Tag.GENOME, Tag.MATE, Tag.HEALTH, Tag.IS_ANALYZED, Tag.MAX_HEALTH);
+	            item.setTagCompound(removeTags(tagsToRemove, tagCompound, flags));
+	            break;
+	        case SAPLING:
+	        case POLLEN:
+	            Collections.addAll(tagsToRemove, Tag.GENOME, Tag.IS_ANALYZED);
+	            item.setTagCompound(removeTags(tagsToRemove, tagCompound, flags));
+	            break;
+	        case BUTTERFLY:
+	        case SERUM:
+	        case CATERPILLAR:
+	        case COCOON:
+	            Collections.addAll(tagsToRemove, Tag.GENOME, Tag.MATE, Tag.HEALTH, Tag.IS_ANALYZED, Tag.MAX_HEALTH, Tag.AGE);
+	            item.setTagCompound(removeTags(tagsToRemove, tagCompound, flags));
+	            break;
+	        default:
+	            throw new IllegalArgumentException("Tried to sanitize \"" + item.getItem().getRegistryName().toString() + "\" for Forestry!");
+	    }
+	    return item;
+    }
+
+    private static NBTTagCompound removeTags(ArrayList<Tag> tagsToRemove, NBTTagCompound compound, int flags) {
+	    for (Tag tag : tagsToRemove) {
+	        if ((flags & tag.flag) == tag.flag && compound.hasKey(tag.name)) {
+		        compound.removeTag(tag.name);
+	        }
+	    }
+	    return compound;
+    }
+}


### PR DESCRIPTION
A common issue with Forestry Bees (and some other things) and automation is that the bee keeps track of how many generations it has gone through and increments an NBT tag GEN each time, resulting in a technically different item every time, making any sort of filter for them unworkable. Not comparing NBT at all makes all bees of all types match, which is unhelpful.
I have altered the itemMatches method to check for appropriate Forestry items, under appropriate situations and strip out the GEN tag when making the comparison between two Forestry items. I also set it to strip out the IS_ANALYZED tag as that serves practically no use in automating bees as well.
The support class is set up so that any of the NBT tags in the breed-able Forestry things can be manipulated as desired, though the GEN tag is the only tag in the way of any automation and anything else is just more fine tuning when dealing how to sort them. You could create buttons for choosing other flags if one wanted and just pass them in; but for now GEN and IS_ANALYZED are hard set whenever comparing NBT on these certain items, which is about all that matters to get automation possible.
It has been tested to be working and does not alter any normal behaviors: if Foresty is not present, if nbt is not being compared, or if the items compared are none of these special Forestry items.