### PR TITLE
Add api method to get a list of all connected blocks

### DIFF
--- a/src/main/java/mcjty/xnet/api/channels/IControllerContext.java
+++ b/src/main/java/mcjty/xnet/api/channels/IControllerContext.java
@@ -3,11 +3,13 @@ package mcjty.xnet.api.channels;
 import mcjty.xnet.api.keys.ConsumerId;
 import mcjty.xnet.api.keys.NetworkId;
 import mcjty.xnet.api.keys.SidedConsumer;
+import mcjty.xnet.api.keys.SidedPos;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.List;
 import java.util.Map;
 
 public interface IControllerContext {
@@ -28,5 +30,7 @@ public interface IControllerContext {
     boolean matchColor(int colorMask);
 
     boolean checkAndConsumeRF(int rft);
+
+    List<SidedPos> getConnectedBlockPositions();
 
 }

--- a/src/main/java/mcjty/xnet/blocks/controller/TileEntityController.java
+++ b/src/main/java/mcjty/xnet/blocks/controller/TileEntityController.java
@@ -337,6 +337,33 @@ public final class TileEntityController extends GenericEnergyReceiverTileEntity 
         return worldBlob.getConsumerPosition(consumerId);
     }
 
+    @Override
+    public List<SidedPos> getConnectedBlockPositions() {
+        WorldBlob worldBlob = XNetBlobData.getBlobData(getWorld()).getWorldBlob(getWorld());
+
+        List<SidedPos> result = new ArrayList<>();
+        Set<ConnectedBlockClientInfo> set = new HashSet<>();
+        for (BlockPos consumerPos : worldBlob.getConsumers(networkId)) {
+            String name = "";
+            TileEntity te = getWorld().getTileEntity(consumerPos);
+            if (te instanceof ConnectorTileEntity) {
+                // Should always be the case. @todo error?
+                name = ((ConnectorTileEntity) te).getConnectorName();
+            } else {
+                XNet.logger.warn("What? The connector at " + BlockPosTools.toString(consumerPos) + " is not a connector?");
+            }
+            for (EnumFacing facing : EnumFacing.VALUES) {
+                if (ConnectorBlock.isConnectable(getWorld(), consumerPos, facing)) {
+                    BlockPos pos = consumerPos.offset(facing);
+                    SidedPos sidedPos = new SidedPos(pos, facing.getOpposite());
+                    result.add(sidedPos);
+                }
+            }
+        }
+
+        return result;
+    }
+
     @Nonnull
     private List<ConnectedBlockClientInfo> findConnectedBlocks() {
         WorldBlob worldBlob = XNetBlobData.getBlobData(getWorld()).getWorldBlob(getWorld());


### PR DESCRIPTION
This allows other mods to iterate over all blocks the controller is
connected to without worrying about configured channels. With this
they can basically piggy-back onto the existing XNet network.

The new getConnectedBlockPositions method is very similiar to the
findConnectedBlocks one, but I wanted to keep this pull request
small and avoid having to introduce ConnectedBlockClientInfo to
the API. Also SidedPos relays exactly the minimum amount of
information to the caller, which is probably preferrable to avoid
potentially unnecessary overhead on each call.