### PR TITLE
A cross dimension fix

### DIFF
--- a/src/main/java/mcjty/xnet/blocks/wireless/TileEntityWirelessRouter.java
+++ b/src/main/java/mcjty/xnet/blocks/wireless/TileEntityWirelessRouter.java
@@ -166,7 +166,14 @@ public final class TileEntityWirelessRouter extends GenericEnergyReceiverTileEnt
 
         // If the dimension is different at this point there is no connection
         if (world.provider.getDimension() != otherRouter.world.provider.getDimension()) {
-            return false;
+            int tier = getAntennaTier();
+            int tierOther = otherRouter.getAntennaTier();
+            
+            if(tier == tierOther && tier == TIER_INF) {
+                return true;
+            } else {
+                return false;
+            }
         }
 
         double maxSqdist = Math.min(thisRange, otherRange);


### PR DESCRIPTION
There's a slide problem if you want to use this mod as a replacement for the enderio "dimensional transceiver". The mod doesn't allow you to comunicate across dimension.

This pull request should fix it. **And by the way i couldn't test it because of a unknown package called "mcjty.lib.datafix.fixes"**

#### Issues fixed:
- https://github.com/McJtyMods/XNet/issues/292