### PR TITLE
Energy Channel extraction/insertion rate missing get()

### DIFF
--- a/src/main/java/mcjty/xnet/apiimpl/energy/EnergyConnectorSettings.java
+++ b/src/main/java/mcjty/xnet/apiimpl/energy/EnergyConnectorSettings.java
@@ -79,7 +79,7 @@ public class EnergyConnectorSettings extends AbstractConnectorSettings {
                 .label("Rate")
                 .integer(TAG_RATE,
                         (energyMode == EnergyMode.EXT ? "Max energy extraction rate" : "Max energy insertion rate") +
-                        "|(limited to " + (advanced ? ConfigSetup.maxRfRateAdvanced : ConfigSetup.maxRfRateNormal) + " per tick)", rate, 40)
+                        "|(limited to " + (advanced ? ConfigSetup.maxRfRateAdvanced.get() : ConfigSetup.maxRfRateNormal.get()) + " per tick)", rate, 40)
                 .shift(10)
                 .label(energyMode == EnergyMode.EXT ? "Min" : "Max")
                 .integer(TAG_MINMAX, energyMode == EnergyMode.EXT ? "Disable extraction if energy|is too low" : "Disable insertion if energy|is too high", minmax, 50);


### PR DESCRIPTION
When hovering over an Xnet Energy Channel's Rate input box, the tooltip does not show the maximum transfer rate, but rather displays a memory address. This is the case for both input and output connectors. This PR fixes that.