### PR TITLE
Fixed creative tab name

### DIFF
--- a/src/main/resources/assets/xnet/lang/en_us.json
+++ b/src/main/resources/assets/xnet/lang/en_us.json
@@ -41,7 +41,7 @@
     "block.xnet.antenna_base": "Antenna Base",
     "block.xnet.antenna_dish": "Antenna Dish",
 
-    "itemGroup.XNet": "XNet",
+    "itemGroup.xnet": "XNet",
 
     "message.xnet.shiftmessage": "<Press Shift>",
 

--- a/src/main/resources/assets/xnet/lang/ko_kr.json
+++ b/src/main/resources/assets/xnet/lang/ko_kr.json
@@ -41,7 +41,7 @@
     "block.xnet.antenna_base": "안테나 베이스",
     "block.xnet.antenna_dish": "안테나 접시",
 
-    "itemGroup.XNet": "엑스넷",
+    "itemGroup.xnet": "엑스넷",
 
     "message.xnet.shiftmessage": "<Shift 입력>",
 


### PR DESCRIPTION
![2020-05-17_02 05 20](https://user-images.githubusercontent.com/5623501/82137128-302f5480-97e3-11ea-9e00-3aaff07a0f3a.png)
This should do it.

I'm not sure if you do something weird with creative tabs but I'm 99% sure this should fix the issue. Too lazy to test. If you don't like it, you can have your money back :)