### PR TITLE
[1.15.2] getColor method results in null pointer

### DIFF
--- a/src/main/java/mcjty/xnet/modules/facade/client/FacadeBlockColor.java
+++ b/src/main/java/mcjty/xnet/modules/facade/client/FacadeBlockColor.java
@@ -13,12 +13,14 @@ import javax.annotation.Nullable;
 public class FacadeBlockColor implements IBlockColor {
     @Override
     public int getColor(BlockState blockState, @Nullable ILightReader world, @Nullable BlockPos pos, int tint) {
-        TileEntity te = world.getTileEntity(pos);
-        if (te instanceof IFacadeSupport) {
-            IFacadeSupport facade = (IFacadeSupport) te;
-            BlockState mimic = facade.getMimicBlock();
-            if (mimic != null) {
-                return Minecraft.getInstance().getBlockColors().getColor(mimic, world, pos, tint);
+        if(world != null)
+            TileEntity te = world.getTileEntity(pos);
+            if (te instanceof IFacadeSupport) {
+                IFacadeSupport facade = (IFacadeSupport) te;
+                BlockState mimic = facade.getMimicBlock();
+                if (mimic != null) {
+                    return Minecraft.getInstance().getBlockColors().getColor(mimic, world, pos, tint);
+                }
             }
         }
 


### PR DESCRIPTION
When the world argument for getColor is null, the method results in a null pointer. The argument is marked is Nullable in IBlockColor.