### PR TITLE
Improve Router GUI

### DIFF
--- a/src/main/java/mcjty/xnet/modules/router/client/GuiRouter.java
+++ b/src/main/java/mcjty/xnet/modules/router/client/GuiRouter.java
@@ -24,6 +24,7 @@ import mcjty.xnet.setup.XNetMessages;
 import net.minecraft.entity.player.PlayerInventory;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.text.TextFormatting;
 
 import java.util.List;
 
@@ -128,29 +129,11 @@ public class GuiRouter extends GenericGuiContainer<TileEntityRouter, GenericCont
         if (channel.isRemote()) {
             labelColor = 0xffaa1133;
         }
-        panel1.children(
-                label("Ch").color(labelColor),
-                label(name),
-                label(">").color(labelColor));
-        if (channel.isRemote()) {
-            panel1.children(new ImageLabel().image(iconGuiElements, 48, 80).desiredWidth(16));
-        }
-        if (local) {
-            TextField pubName = new TextField().text(publishedName).desiredWidth(50).desiredHeight(13)
-                    .event((newText) -> updatePublish(controllerPos, index, newText));
-            panel1.children(pubName);
-        } else {
-            panel1.children(label(publishedName).color(0xff33ff00));
-        }
-
-        Panel panel2 = horizontal(0, 0).hint(0, 13, 160, 13)
-                .children(
-                        label("Pos").color(labelColor),
-                        label(BlockPosTools.toString(controllerPos)));
 
         // Represent channel number/type in the same way as
         // in GuiController.drawGuiContainerBackgroundLayer().
         Label numTypeLabel = label(num);
+        numTypeLabel.tooltips(TextFormatting.GREEN + "Channel type: " + TextFormatting.WHITE + type.getName());
         IChannelSettings settings = type.createChannel();
         if (settings != null) {
                 IndicatorIcon icon = settings.getIndicatorIcon();
@@ -163,11 +146,28 @@ public class GuiRouter extends GenericGuiContainer<TileEntityRouter, GenericCont
                 }
         }
 
+        panel1.children(
+                label("Ch").color(labelColor),
+                numTypeLabel,
+                label(name));
+
+        Panel panel2 = horizontal(0, 0).hint(0, 13, 160, 13)
+                .children(label("Pub").color(labelColor));
+        if (channel.isRemote()) {
+            panel2.children(new ImageLabel().image(iconGuiElements, 48, 80).desiredWidth(16));
+        }
+        if (local) {
+            TextField pubName = new TextField().text(publishedName).desiredWidth(50).desiredHeight(13)
+                    .event((newText) -> updatePublish(controllerPos, index, newText));
+            panel2.children(pubName);
+        } else {
+            panel2.children(label(publishedName).color(0xff33ff00));
+        }
+
         Panel panel3 = horizontal(0, 0).hint(0, 26, 160, 13)
                 .children(
-                        label("Num").color(labelColor),
-                        numTypeLabel,
-                        label("(" + type.getName() + ")"));
+                        label("Pos").color(labelColor),
+                        label(BlockPosTools.toString(controllerPos)));
 
         panel.children(panel1, panel2, panel3);
         return panel;

--- a/src/main/java/mcjty/xnet/modules/router/client/GuiRouter.java
+++ b/src/main/java/mcjty/xnet/modules/router/client/GuiRouter.java
@@ -116,6 +116,7 @@ public class GuiRouter extends GenericGuiContainer<TileEntityRouter, GenericCont
         BlockPos controllerPos = channel.getPos();
         IChannelType type = channel.getChannelType();
         int index = channel.getIndex();
+        String num = String.valueOf(index + 1);
 
         Panel panel = positional().desiredHeight(30);
         Panel panel1 = horizontal(0, 0).hint(0, 0, 160, 13);
@@ -146,8 +147,8 @@ public class GuiRouter extends GenericGuiContainer<TileEntityRouter, GenericCont
 
         Panel panel3 = horizontal(0, 0).hint(0, 26, 160, 13)
                 .children(
-                        label("Index").color(labelColor),
-                        label(index + " (" + type.getName() + ")"));
+                        label("Num").color(labelColor),
+                        label(num + " (" + type.getName() + ")"));
 
         panel.children(panel1, panel2, panel3);
         return panel;

--- a/src/main/java/mcjty/xnet/modules/router/client/GuiRouter.java
+++ b/src/main/java/mcjty/xnet/modules/router/client/GuiRouter.java
@@ -5,12 +5,15 @@ import mcjty.lib.container.GenericContainer;
 import mcjty.lib.gui.GenericGuiContainer;
 import mcjty.lib.gui.Window;
 import mcjty.lib.gui.widgets.ImageLabel;
+import mcjty.lib.gui.widgets.Label;
 import mcjty.lib.gui.widgets.Panel;
 import mcjty.lib.gui.widgets.TextField;
 import mcjty.lib.gui.widgets.WidgetList;
 import mcjty.lib.typed.TypedMap;
 import mcjty.lib.varia.BlockPosTools;
+import mcjty.rftoolsbase.api.xnet.channels.IChannelSettings;
 import mcjty.rftoolsbase.api.xnet.channels.IChannelType;
+import mcjty.rftoolsbase.api.xnet.gui.IndicatorIcon;
 import mcjty.xnet.XNet;
 import mcjty.xnet.client.ControllerChannelClientInfo;
 import mcjty.xnet.modules.router.RouterModule;
@@ -145,10 +148,26 @@ public class GuiRouter extends GenericGuiContainer<TileEntityRouter, GenericCont
                         label("Pos").color(labelColor),
                         label(BlockPosTools.toString(controllerPos)));
 
+        // Represent channel number/type in the same way as
+        // in GuiController.drawGuiContainerBackgroundLayer().
+        Label numTypeLabel = label(num);
+        IChannelSettings settings = type.createChannel();
+        if (settings != null) {
+                IndicatorIcon icon = settings.getIndicatorIcon();
+                if (icon != null) {
+                        numTypeLabel.image(icon.getImage(), icon.getU(), icon.getV(), icon.getIw(), icon.getIh());
+                }
+                String indicator = settings.getIndicator();
+                if (indicator != null) {
+                        numTypeLabel.text(indicator + num);
+                }
+        }
+
         Panel panel3 = horizontal(0, 0).hint(0, 26, 160, 13)
                 .children(
                         label("Num").color(labelColor),
-                        label(num + " (" + type.getName() + ")"));
+                        numTypeLabel,
+                        label("(" + type.getName() + ")"));
 
         panel.children(panel1, panel2, panel3);
         return panel;


### PR DESCRIPTION
This is an attempt to improve the Router GUI: Get away with cryptic block coordinates & channel indices, count up Controller numbers and use 1-based channel numbers that correspond to the Controller GUI, instead.

The head commit is only meant as a suggestion, but everything up to it seem reasonable to me.

Before:
![2021-02-17_22 23 26-local_build_of_unmodified_upstream](https://user-images.githubusercontent.com/21263089/108316858-c1da5100-71bd-11eb-82b5-fdd9c7527ab9.png)

After 8d1b9ca:
![2021-02-18_05 21 10-router_1](https://user-images.githubusercontent.com/21263089/108317068-0fef5480-71be-11eb-91a8-228da2267f5f.png)

After 9e9df43:
![2021-02-18_06 53 20-router_1](https://user-images.githubusercontent.com/21263089/108317145-24cbe800-71be-11eb-83ca-fe57d8adc2bb.png)

Please bear with me as this is the first time I've coded for a Minecraft mod.